### PR TITLE
fix: remove $schema key from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "hugoguerrap",
   "owner": {
     "name": "hugoguerrap"


### PR DESCRIPTION
## Summary

The `$schema` key in `.claude-plugin/marketplace.json` is not part of the Claude Code plugin manifest specification and causes validation errors.

## Changes

- Removed the `"$schema"` line from `.claude-plugin/marketplace.json`
- All other fields are unchanged

This ensures the plugin manifest conforms to the Claude Code plugin specification.